### PR TITLE
Load 'cl-lib' for using 'cl-case'

### DIFF
--- a/magic-latex-buffer.el
+++ b/magic-latex-buffer.el
@@ -19,6 +19,7 @@
 ;; Author: zk_phi
 ;; URL: http://hins11.yu-yake.com/
 ;; Version: 0.0.0
+;; Package-Requires: ((cl-lib "0.5"))
 
 ;;; Commentary:
 
@@ -43,6 +44,7 @@
 (require 'font-lock)
 (require 'jit-lock)
 (require 'tex-mode)
+(require 'cl-lib)
 
 ;; + development notes
 


### PR DESCRIPTION
I got following error when `magic-latex-buffer.el` is byte-compiled.
This patch fixes this byte-compile warnings. Please see this patch.

```
In ml/jit-prettifier:
magic-latex-buffer.el:630:31:Warning: `(95)' is a malformed function
magic-latex-buffer.el:630:31:Warning: `(94)' is a malformed function

In end of data:
magic-latex-buffer.el:680:1:Warning: the function `cl-case' is not known to be
    defined.
```
