### PR TITLE
 Add cref to regexp-opt and new symbols

### DIFF
--- a/magic-latex-buffer.el
+++ b/magic-latex-buffer.el
@@ -393,7 +393,7 @@ K-th ARG if succeeded."
         (citations
          (ml/command-matcher
           (ml/command-regexp-opt
-           '("label" "ref" "pageref" "vref" "eqref" "cite" "Cite"
+           '("label" "ref" "pageref" "vref" "eqref" "cite" "Cite" "cref"
              "nocite" "index" "glossary" "bibitem" "citep" "citet")) t 1))
         (quotes
          (concat (regexp-opt `("``" "\"<" "\"`" "<<" "«") t)
@@ -686,6 +686,8 @@ between BEG and END."
     ("\\\\to\\>" . "→") ("\\\\mapsto\\>" . "↦")
     ("\\\\colon\\>" . ":")
     ("\\\\propto\\>" . "∝")
+    ("\\\\coloneqq\\>" . ":=")
+    ("\\\\eqqcolon\\>" . "=:")
 
     ;; set
     ("\\\\subseteq\\>" . "⊆") ("\\\\subset\\>" . "⊂")
@@ -907,6 +909,8 @@ between BEG and END."
     ("\\\\\\(?:dot\\|\\.\\){\\([^}]\\)}"
      . (compose-chars (string-to-char (match-string 1)) '(cc Bc 0 60) ?・))
     ("\\\\\\(?:hat\\|\\^\\){\\([^}]\\)}"
+     . (compose-chars (string-to-char (match-string 1)) '(cc Bc 0 45) ?^))
+    ("\\\\\\(?:widehat\\|\\^\\){\\([^}]\\)}"
      . (compose-chars (string-to-char (match-string 1)) '(cc Bc 0 45) ?^))
     ("\\\\\\(?:acute\\|'\\){\\([^}]\\)}"
      . (compose-chars (string-to-char (match-string 1)) '(cc Bc 0 45) ?'))


### PR DESCRIPTION
  Add cref to regexp-opt
  Add \coloneqq and \eqqcolon as := and  =:;
 Consider \widehat as \hat